### PR TITLE
refactor: minor optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,13 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] 
 [[bench]]
 name = "basic"
 harness = false
+
+[profile.bench]
+opt-level = 3
+debug = false
+codegen-units = 1
+lto = 'fat'
+incremental = false
+debug-assertions = false
+overflow-checks = false
+rpath = false

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -45,6 +45,27 @@ async fn test() {
     }
 }
 
+async fn test_baseline() {
+    async fn test_inner() {
+        futures::future::join(
+            async {
+                yield_now().await;
+                black_box(1)
+            },
+            async {
+                yield_now().await;
+                yield_now().await;
+                black_box(2)
+            },
+        )
+        .await;
+    }
+
+    for _ in 0..10000 {
+        test_inner().await;
+    }
+}
+
 // time:   [6.5488 ms 6.5541 ms 6.5597 ms]
 // change: [+6.5978% +6.7838% +6.9299%] (p = 0.00 < 0.05)
 // Performance has regressed.
@@ -60,5 +81,18 @@ fn bench_basic(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_basic);
+fn bench_basic_baseline(c: &mut Criterion) {
+    c.bench_function("basic", |b| {
+        b.to_async(runtime()).iter(|| async {
+            let config = ConfigBuilder::default().verbose(false).build().unwrap();
+            let mut mgr = Registry::new(config);
+
+            let root = mgr.register(233, "root");
+            black_box(root);
+            test_baseline().await
+        })
+    });
+}
+
+criterion_group!(benches, bench_basic, bench_basic_baseline);
 criterion_main!(benches);

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -82,7 +82,7 @@ fn bench_basic(c: &mut Criterion) {
 }
 
 fn bench_basic_baseline(c: &mut Criterion) {
-    c.bench_function("basic", |b| {
+    c.bench_function("basic_baseline", |b| {
         b.to_async(runtime()).iter(|| async {
             let config = ConfigBuilder::default().verbose(false).build().unwrap();
             let mut mgr = Registry::new(config);

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 
 use indextree::{Arena, NodeId};
 use itertools::Itertools;
+use parking_lot::{Mutex, MutexGuard};
 
 use crate::Span;
 
@@ -45,15 +46,8 @@ impl SpanNode {
 /// against the current task-local context before trying to update the tree.
 pub(crate) type ContextId = u64;
 
-/// The task-local await-tree context.
 #[derive(Debug, Clone)]
-pub struct TreeContext {
-    /// The id of the context.
-    id: ContextId,
-
-    /// Whether to include the "verbose" span in the tree.
-    verbose: bool,
-
+pub struct Tree {
     /// The arena for allocating span nodes in this context.
     arena: Arena<SpanNode>,
 
@@ -64,7 +58,7 @@ pub struct TreeContext {
     current: NodeId,
 }
 
-impl std::fmt::Display for TreeContext {
+impl std::fmt::Display for Tree {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         fn fmt_node(
             f: &mut std::fmt::Formatter<'_>,
@@ -123,24 +117,7 @@ impl std::fmt::Display for TreeContext {
     }
 }
 
-impl TreeContext {
-    /// Create a new context.
-    pub(crate) fn new(root_span: Span, verbose: bool) -> Self {
-        static ID: AtomicU64 = AtomicU64::new(0);
-        let id = ID.fetch_add(1, Ordering::SeqCst);
-
-        let mut arena = Arena::new();
-        let root = arena.new_node(SpanNode::new(root_span));
-
-        Self {
-            id,
-            verbose,
-            arena,
-            root,
-            current: root,
-        }
-    }
-
+impl Tree {
     /// Get the count of active span nodes in this context.
     #[cfg(test)]
     pub(crate) fn active_node_count(&self) -> usize {
@@ -214,14 +191,53 @@ impl TreeContext {
         node.remove(&mut self.arena);
     }
 
-    /// Whether the verbose span should be included.
-    pub(crate) fn verbose(&self) -> bool {
-        self.verbose
-    }
-
     /// Get the current span node id.
     pub(crate) fn current(&self) -> NodeId {
         self.current
+    }
+}
+
+/// The task-local await-tree context.
+#[derive(Debug)]
+pub struct TreeContext {
+    /// The id of the context.
+    id: ContextId,
+
+    /// Whether to include the "verbose" span in the tree.
+    verbose: bool,
+
+    ///
+    tree: Mutex<Tree>,
+}
+
+impl TreeContext {
+    /// Create a new context.
+    pub(crate) fn new(root_span: Span, verbose: bool) -> Self {
+        static ID: AtomicU64 = AtomicU64::new(0);
+        let id = ID.fetch_add(1, Ordering::SeqCst);
+
+        let mut arena = Arena::new();
+        let root = arena.new_node(SpanNode::new(root_span));
+
+        Self {
+            id,
+            verbose,
+            tree: Tree {
+                arena,
+                root,
+                current: root,
+            }
+            .into(),
+        }
+    }
+
+    pub(crate) fn tree(&self) -> MutexGuard<'_, Tree> {
+        self.tree.lock()
+    }
+
+    /// Whether the verbose span should be included.
+    pub(crate) fn verbose(&self) -> bool {
+        self.verbose
     }
 }
 
@@ -234,34 +250,26 @@ impl TreeContext {
 }
 
 tokio::task_local! {
-    pub(crate) static CONTEXT: Arc<parking_lot::Mutex<TreeContext>>
+    pub(crate) static CONTEXT: Arc<TreeContext>
 }
 
 pub(crate) fn with_context<F, R>(f: F) -> R
 where
-    F: FnOnce(&mut TreeContext) -> R,
+    F: FnOnce(&TreeContext) -> R,
 {
-    CONTEXT.with(|context| {
-        let mut context = context.lock();
-        f(&mut context)
-    })
+    try_with_context(f).unwrap()
 }
 
 pub(crate) fn try_with_context<F, R>(f: F) -> Option<R>
 where
-    F: FnOnce(&mut TreeContext) -> R,
+    F: FnOnce(&TreeContext) -> R,
 {
-    CONTEXT
-        .try_with(|context| {
-            let mut context = context.lock();
-            f(&mut context)
-        })
-        .ok()
+    CONTEXT.try_with(|t| f(&*t)).ok()
 }
 
 /// Get the await-tree context of current task. Returns `None` if we're not instrumented.
 ///
 /// This is useful if you want to check which component or runtime task is calling this function.
-pub fn current_tree() -> Option<TreeContext> {
-    try_with_context(|c| c.clone())
+pub fn current_tree() -> Option<Tree> {
+    try_with_context(|c| c.tree().clone())
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -46,6 +46,7 @@ impl SpanNode {
 /// against the current task-local context before trying to update the tree.
 pub(crate) type ContextId = u64;
 
+/// An await-tree for a task.
 #[derive(Debug, Clone)]
 pub struct Tree {
     /// The arena for allocating span nodes in this context.
@@ -207,7 +208,7 @@ pub struct TreeContext {
     /// Whether to include the "verbose" span in the tree.
     verbose: bool,
 
-    ///
+    /// The await-tree.
     tree: Mutex<Tree>,
 }
 
@@ -232,6 +233,7 @@ impl TreeContext {
         }
     }
 
+    /// Returns the locked guard of the tree.
     pub(crate) fn tree(&self) -> MutexGuard<'_, Tree> {
         self.tree.lock()
     }
@@ -258,7 +260,7 @@ pub(crate) fn context() -> Option<Arc<TreeContext>> {
     CONTEXT.try_with(Arc::clone).ok()
 }
 
-/// Get the await-tree context of current task. Returns `None` if we're not instrumented.
+/// Get the await-tree of current task. Returns `None` if we're not instrumented.
 ///
 /// This is useful if you want to check which component or runtime task is calling this function.
 pub fn current_tree() -> Option<Tree> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -132,7 +132,7 @@ async fn hello() {
     .await;
 
     // Aborted futures have been cleaned up. There should only be a single active node of root.
-    assert_eq!(with_context(|c| c.active_node_count()), 1);
+    assert_eq!(with_context(|c| c.tree().active_node_count()), 1);
 }
 
 #[tokio::test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -16,7 +16,7 @@ use futures::future::{join_all, poll_fn, select_all};
 use futures::{pin_mut, FutureExt, Stream, StreamExt};
 use itertools::Itertools;
 
-use crate::context::with_context;
+use crate::context::context;
 use crate::{Config, InstrumentAwait, Registry};
 
 async fn sleep(time: u64) {
@@ -132,7 +132,7 @@ async fn hello() {
     .await;
 
     // Aborted futures have been cleaned up. There should only be a single active node of root.
-    assert_eq!(with_context(|c| c.tree().active_node_count()), 1);
+    assert_eq!(context().unwrap().tree().active_node_count(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

- Only lock the mutable `Tree` part of the context.
- Reduce accessing times of the thread-local variable.
- Add a baseline benchmark and tweak the `bench` profile.