### PR TITLE
refactor: use weak-table for registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
+weak-table = "0.3.2"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async", "async_tokio"] }

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use await_tree::{ConfigBuilder, InstrumentAwait, Registry};
+use std::time::Duration;
+
+use await_tree::{Config, ConfigBuilder, InstrumentAwait, Registry};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tokio::runtime::{Builder, Runtime};
 use tokio::task::yield_now;
@@ -66,6 +68,33 @@ async fn test_baseline() {
     }
 }
 
+async fn spawn_many(size: usize) {
+    let mut root = Registry::new(Config::default());
+    let mut handles = vec![];
+    for i in 0..size {
+        let task = async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        handles.push(tokio::spawn(root.register(i, "new_task").instrument(task)));
+    }
+    futures::future::try_join_all(handles)
+        .await
+        .expect("failed to join background task");
+}
+
+async fn spawn_many_baseline(size: usize) {
+    let mut handles = vec![];
+    for _ in 0..size {
+        let task = async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        handles.push(tokio::spawn(task));
+    }
+    futures::future::try_join_all(handles)
+        .await
+        .expect("failed to join background task");
+}
+
 // time:   [6.5488 ms 6.5541 ms 6.5597 ms]
 // change: [+6.5978% +6.7838% +6.9299%] (p = 0.00 < 0.05)
 // Performance has regressed.
@@ -95,4 +124,24 @@ fn bench_basic_baseline(c: &mut Criterion) {
 }
 
 criterion_group!(benches, bench_basic, bench_basic_baseline);
-criterion_main!(benches);
+
+// with_register_to_root   time:   [15.993 ms 16.122 ms 16.292 ms]
+// baseline                time:   [13.940 ms 13.961 ms 13.982 ms]
+
+fn bench_many_baseline(c: &mut Criterion) {
+    c.bench_function("with_register_to_root_baseline", |b| {
+        b.to_async(runtime())
+            .iter(|| async { black_box(spawn_many_baseline(10000)).await })
+    });
+}
+
+fn bench_many_exp(c: &mut Criterion) {
+    c.bench_function("with_register_to_root", |b| {
+        b.to_async(runtime())
+            .iter(|| async { black_box(spawn_many(10000)).await })
+    });
+}
+
+criterion_group!(bench_many, bench_many_exp, bench_many_baseline);
+
+criterion_main!(benches, bench_many);

--- a/benches/basic.rs
+++ b/benches/basic.rs
@@ -142,6 +142,10 @@ fn bench_many_exp(c: &mut Criterion) {
     });
 }
 
-criterion_group!(bench_many, bench_many_exp, bench_many_baseline);
+criterion_group!(
+    name = bench_many;
+    config = Criterion::default().sample_size(50);
+    targets = bench_many_exp, bench_many_baseline
+);
 
 criterion_main!(benches, bench_many);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -133,3 +133,25 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use crate::Registry;
+
+    #[test]
+    fn test_delay_gc() {
+        let mut reg = Registry::new(crate::Config {
+            verbose: false,
+            gc_throttle_duration: Duration::from_millis(100),
+        });
+        for i in 0..100 {
+            let _ = reg.register(i, "gc_me");
+        }
+        assert_eq!(reg.contexts.len(), 100);
+        std::thread::sleep(Duration::from_millis(100));
+        reg.register(101, "not_yet_to_gc_me");
+        assert_eq!(reg.contexts.len(), 1);
+    }
+}

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -13,14 +13,12 @@
 // limitations under the License.
 
 use std::borrow::Borrow;
-use std::collections::HashMap;
 use std::future::Future;
 use std::hash::Hash;
 use std::sync::{Arc, Weak};
-use std::time::Duration;
 
-use coarsetime::Instant;
 use derive_builder::Builder;
+use weak_table::WeakValueHashMap;
 
 use crate::context::{Tree, TreeContext, CONTEXT};
 use crate::Span;
@@ -32,19 +30,12 @@ use crate::Span;
 pub struct Config {
     /// Whether to include the **verbose** span in the await-tree.
     verbose: bool,
-    /// The minimal gap of triggering GC.
-    /// Generally GC will be triggered each time registering new futures to
-    /// the registry. (e.g. spawning new tasks to the runtime.)
-    gc_throttle_duration: Duration,
 }
 
 #[allow(clippy::derivable_impls)]
 impl Default for Config {
     fn default() -> Self {
-        Self {
-            verbose: false,
-            gc_throttle_duration: Duration::from_secs(1),
-        }
+        Self { verbose: false }
     }
 }
 
@@ -63,17 +54,18 @@ impl TreeRoot {
 /// The registry of multiple await-trees.
 #[derive(Debug)]
 pub struct Registry<K> {
-    contexts: HashMap<K, Weak<TreeContext>>,
-    last_gc: Instant,
+    contexts: WeakValueHashMap<K, Weak<TreeContext>>,
     config: Config,
 }
 
-impl<K> Registry<K> {
+impl<K> Registry<K>
+where
+    K: std::hash::Hash + Eq + std::fmt::Debug,
+{
     /// Create a new registry with given `config`.
     pub fn new(config: Config) -> Self {
         Self {
-            contexts: HashMap::new(),
-            last_gc: Instant::recent(),
+            contexts: WeakValueHashMap::new(),
             config,
         }
     }
@@ -88,20 +80,15 @@ where
     /// If the key already exists, a new [`TreeRoot`] is returned and the reference to the old
     /// [`TreeRoot`] is dropped.
     pub fn register(&mut self, key: K, root_span: impl Into<Span>) -> TreeRoot {
-        self.maybe_gc();
-
         let context = Arc::new(TreeContext::new(root_span.into(), self.config.verbose));
-        let weak = Arc::downgrade(&context);
-        self.contexts.insert(key, weak);
+        self.contexts.insert(key, Arc::clone(&context));
 
         TreeRoot { context }
     }
 
     /// Iterate over the clones of all registered await-trees.
     pub fn iter(&self) -> impl Iterator<Item = (&K, Tree)> {
-        self.contexts
-            .iter()
-            .filter_map(|(k, v)| v.upgrade().map(|v| (k, v.tree().clone())))
+        self.contexts.iter().map(|(k, v)| (k, v.tree().clone()))
     }
 
     /// Get a clone of the await-tree with given key.
@@ -112,46 +99,11 @@ where
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        self.contexts
-            .get(k)
-            .and_then(|v| v.upgrade())
-            .map(|v| v.tree().clone())
+        self.contexts.get(k).map(|v| v.tree().clone())
     }
 
     /// Remove all the registered await-trees.
     pub fn clear(&mut self) {
         self.contexts.clear();
-    }
-
-    fn maybe_gc(&mut self) {
-        Instant::update();
-        let since_last_gc = self.last_gc.elapsed_since_recent();
-        if since_last_gc > self.config.gc_throttle_duration.into() {
-            // TODO: make this more efficient
-            self.contexts.retain(|_, v| v.upgrade().is_some());
-            self.last_gc = Instant::recent();
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use crate::Registry;
-
-    #[test]
-    fn test_delay_gc() {
-        let mut reg = Registry::new(crate::Config {
-            verbose: false,
-            gc_throttle_duration: Duration::from_millis(100),
-        });
-        for i in 0..100 {
-            let _ = reg.register(i, "gc_me");
-        }
-        assert_eq!(reg.contexts.len(), 100);
-        std::thread::sleep(Duration::from_millis(100));
-        reg.register(101, "not_yet_to_gc_me");
-        assert_eq!(reg.contexts.len(), 1);
     }
 }


### PR DESCRIPTION
cc #8, in the benchmark of spawning 10,000 tasks in a short time, there is a 20x performance improve. Even it won't be so dramatic in real case, I hope this can make this awesome library more scalable. 

A tiny difference of the description in #8 is that this PR made the default value be 1s and the option not wrapped by `Option`.

![image](https://github.com/risingwavelabs/await-tree/assets/36239017/2c17ab12-46a2-46e0-bc57-46470dc0b022)
