### PR TITLE
feat: support instrument stream under TreeRoot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ categories = ["development-tools::debugging"]
 license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+stream = ["futures-core"]
+
 [dependencies]
 coarsetime = "0.1"
 derive_builder = "0.12"
@@ -20,6 +23,7 @@ pin-project = "1"
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
 weak-table = "0.3.2"
+futures-core = { version = "0.3", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["async", "async_tokio"] }


### PR DESCRIPTION
I want `await-tree` to track a request stream passed to tonic. But the root future of tonic is apparently not under our control.

```rust
let req_stream = async_stream! {
    while x {
        whatever_fut.instrument_await("y").await; // not under any tree
        yield z;
    }
};
tonic_client.stream_rpc(req_stream);
```

And it doesn't work to use a customized executor that wraps every future with a `TreeRoot`. (Flood of `future polled in a different context as it was first polled` and `future is dropped in a different context as it was first poll`).

So, the best we can do is create a `TreeRoot` for the stream:

```rust
tonic_client.stream_rpc(tree_root.instrument_stream(req_stream));
```