### PR TITLE
add a `span!` macro as the replacement of `format!` with better performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ async fn bar(i: i32) {
 
 async fn baz(i: i32) {
     // runtime `String` span is also supported
-    work().instrument_await(format!("working in baz {i}")).await
+    work().instrument_await(span!("working in baz {i}")).await
 }
 
 async fn foo() {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -16,7 +16,7 @@
 
 use std::time::Duration;
 
-use await_tree::{Config, InstrumentAwait, Registry};
+use await_tree::{span, Config, InstrumentAwait, Registry};
 use futures::future::{join, pending};
 use tokio::time::sleep;
 
@@ -28,7 +28,7 @@ async fn bar(i: i32) {
 async fn baz(i: i32) {
     // runtime `String` span is also supported
     pending()
-        .instrument_await(format!("pending in baz {i}"))
+        .instrument_await(span!("pending in baz {i}"))
         .await
 }
 

--- a/examples/multiple.rs
+++ b/examples/multiple.rs
@@ -16,13 +16,13 @@
 
 use std::time::Duration;
 
-use await_tree::{Config, InstrumentAwait, Registry};
+use await_tree::{span, Config, InstrumentAwait, Registry};
 use futures::future::pending;
 use itertools::Itertools;
 use tokio::time::sleep;
 
 async fn work(i: i32) {
-    foo().instrument_await(format!("actor work {i}")).await
+    foo().instrument_await(span!("actor work {i}")).await
 }
 
 async fn foo() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! ```rust
 //! # use std::time::Duration;
 //! # use tokio::time::sleep;
-//! # use await_tree::{InstrumentAwait, Registry};
+//! # use await_tree::{InstrumentAwait, Registry, span};
 //! # use futures::future::join;
 //! #
 //! # async fn work() { futures::future::pending::<()>().await }
@@ -34,7 +34,7 @@
 //!
 //! async fn baz(i: i32) {
 //!     // runtime `String` span is also supported
-//!     work().instrument_await(format!("working in baz {i}")).await
+//!     work().instrument_await(span!("working in baz {i}")).await
 //! }
 //!
 //! async fn foo() {
@@ -87,6 +87,11 @@ pub use registry::{AnyKey, Config, ConfigBuilder, ConfigBuilderError, Key, Regis
 pub use root::TreeRoot;
 pub use span::{Span, SpanExt};
 pub use spawn::{spawn, spawn_anonymous};
+
+#[doc(hidden)]
+pub mod __private {
+    pub use crate::span::fmt_span;
+}
 
 /// Attach spans to a future to be traced in the await-tree.
 pub trait InstrumentAwait: Future + Sized {

--- a/src/span.rs
+++ b/src/span.rs
@@ -15,7 +15,7 @@
 type SpanName = flexstr::SharedStr;
 
 #[doc(hidden)]
-pub fn fmt_span<'a>(args: std::fmt::Arguments<'a>) -> Span {
+pub fn fmt_span(args: std::fmt::Arguments<'_>) -> Span {
     let name = if let Some(str) = args.as_str() {
         SpanName::from_ref(str)
     } else {

--- a/src/span.rs
+++ b/src/span.rs
@@ -14,12 +14,49 @@
 
 type SpanName = flexstr::SharedStr;
 
+#[doc(hidden)]
+pub fn fmt_span<'a>(args: std::fmt::Arguments<'a>) -> Span {
+    let name = if let Some(str) = args.as_str() {
+        SpanName::from_ref(str)
+    } else {
+        flexstr::flex_fmt(args)
+    };
+    Span::new(name)
+}
+
+/// Creates a new span with formatted name.
+///
+/// [`instrument_await`] accepts any type that implements [`AsRef<str>`] as the span name.
+/// This macro provides similar functionality to [`format!`], but with improved performance
+/// by creating the span name on the stack when possible, avoiding unnecessary allocations.
+///
+/// [`instrument_await`]: crate::InstrumentAwait::instrument_await
+#[macro_export]
+// XXX: Without this extra binding (`let res = ..`), it will make the future `!Send`.
+//      This is also how `std::format!` behaves. But why?
+macro_rules! span {
+    ($($fmt_arg:tt)*) => {{
+        let res = $crate::__private::fmt_span(format_args!($($fmt_arg)*));
+        res
+    }};
+}
+
 /// A cheaply cloneable span in the await-tree.
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Span {
     pub(crate) name: SpanName,
     pub(crate) is_verbose: bool,
     pub(crate) is_long_running: bool,
+}
+
+impl Span {
+    fn new(name: SpanName) -> Self {
+        Self {
+            name,
+            is_verbose: false,
+            is_long_running: false,
+        }
+    }
 }
 
 impl Span {
@@ -67,11 +104,7 @@ impl<T: Into<Span>> T {
 
 impl<S: AsRef<str>> From<S> for Span {
     fn from(value: S) -> Self {
-        Self {
-            name: SpanName::from_ref(value),
-            is_long_running: false,
-            is_verbose: false,
-        }
+        Self::new(SpanName::from_ref(value))
     }
 }
 

--- a/src/tests/functionality.rs
+++ b/src/tests/functionality.rs
@@ -17,7 +17,7 @@ use futures::{pin_mut, FutureExt, Stream, StreamExt};
 use itertools::Itertools;
 
 use crate::root::current_context;
-use crate::{Config, InstrumentAwait, Registry};
+use crate::{span, Config, InstrumentAwait, Registry};
 
 async fn sleep(time: u64) {
     tokio::time::sleep(std::time::Duration::from_millis(time)).await;
@@ -77,7 +77,7 @@ async fn hello() {
         join_all([
             sleep(1000)
                 .boxed()
-                .instrument_await(format!("sleep {}", 1000)),
+                .instrument_await(span!("sleep {}", 1000)),
             sleep(2000).boxed().instrument_await("sleep 2000"),
             sleep_nested().boxed().instrument_await("sleep nested"),
             multi_sleep().boxed().instrument_await("multi sleep"),
@@ -111,13 +111,13 @@ async fn hello() {
 
             'outer: loop {
                 tokio::select! {
-                    _ = stream1.next().instrument_await(format!("stream1 next {count}")) => {},
-                    r = stream2.next().instrument_await(format!("stream2 next {count}")) => {
+                    _ = stream1.next().instrument_await(span!("stream1 next {count}")) => {},
+                    r = stream2.next().instrument_await(span!("stream2 next {count}")) => {
                         if r.is_none() { break 'outer }
                     },
                 }
                 sleep(50)
-                    .instrument_await(format!("sleep before next stream poll: {count}"))
+                    .instrument_await(span!("sleep before next stream poll: {count}"))
                     .await;
                 count += 1;
             }


### PR DESCRIPTION
Add a macro `span!` which internally calls `flexstr::flex_fmt`, so that if the name is short, there's no allocation for dynamic span names as well.