### PR TITLE
impl `serde::Serialize` for tree to provide structured output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,12 @@ license = "Apache-2.0"
 coarsetime = "0.1"
 derive_builder = "0.20"
 easy-ext = "1"
-flexstr = "0.9"
+flexstr = { version = "0.9", features = ["serde"] }
 indextree = "4"
 itertools = "0.12"
 parking_lot = "0.12"
 pin-project = "1"
+serde = "1"
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
 weak-table = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ indextree = "4"
 itertools = "0.12"
 parking_lot = "0.12"
 pin-project = "1"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"
 weak-table = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ weak-table = "0.3.2"
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+serde_json = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "macros"] }
 
 [[bench]]

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,0 +1,179 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This example shows the serialization format of the tree.
+//!
+//! The execution flow is the same as `examples/detach.rs`.
+
+use std::time::Duration;
+
+use await_tree::{Config, InstrumentAwait, Registry};
+use futures::channel::oneshot::{self, Receiver};
+use futures::future::{pending, select};
+use futures::FutureExt;
+use tokio::time::sleep;
+
+async fn work(rx: Receiver<()>) {
+    let mut fut = pending().instrument_await("fut");
+
+    // poll `fut` under the `select` span
+    let _ = select(
+        sleep(Duration::from_millis(500))
+            .instrument_await("sleep")
+            .boxed(),
+        &mut fut,
+    )
+    .instrument_await("select")
+    .await;
+
+    // `select` span closed so `fut` is detached
+    // the elapsed time of `fut` should be preserved
+
+    // wait for the signal to continue
+    rx.instrument_await("rx").await.unwrap();
+
+    // poll `fut` under the root `work` span, and it'll be remounted
+    fut.await
+}
+
+#[tokio::main]
+async fn main() {
+    let registry = Registry::new(Config::default());
+    let root = registry.register((), "work");
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(root.instrument(work(rx)));
+
+    sleep(Duration::from_millis(100)).await;
+    let tree = serde_json::to_string_pretty(&registry.get(()).unwrap()).unwrap();
+
+    // {
+    //   "current": 1,
+    //   "tree": {
+    //     "id": 1,
+    //     "span": {
+    //       "name": "work",
+    //       "is_verbose": false,
+    //       "is_long_running": true
+    //     },
+    //     "elapsed_ns": 105404875,
+    //     "children": [
+    //       {
+    //         "id": 2,
+    //         "span": {
+    //           "name": "select",
+    //           "is_verbose": false,
+    //           "is_long_running": false
+    //         },
+    //         "elapsed_ns": 105287624,
+    //         "children": [
+    //           {
+    //             "id": 3,
+    //             "span": {
+    //               "name": "sleep",
+    //               "is_verbose": false,
+    //               "is_long_running": false
+    //             },
+    //             "elapsed_ns": 105267874,
+    //             "children": []
+    //           },
+    //           {
+    //             "id": 4,
+    //             "span": {
+    //               "name": "fut",
+    //               "is_verbose": false,
+    //               "is_long_running": false
+    //             },
+    //             "elapsed_ns": 105264874,
+    //             "children": []
+    //           }
+    //         ]
+    //       }
+    //     ]
+    //   },
+    //   "detached": []
+    // }
+    println!("{tree}");
+
+    sleep(Duration::from_secs(1)).await;
+    let tree = serde_json::to_string_pretty(&registry.get(()).unwrap()).unwrap();
+
+    // {
+    //   "current": 1,
+    //   "tree": {
+    //     "id": 1,
+    //     "span": {
+    //       "name": "work",
+    //       "is_verbose": false,
+    //       "is_long_running": true
+    //     },
+    //     "elapsed_ns": 1108552791,
+    //     "children": [
+    //       {
+    //         "id": 3,
+    //         "span": {
+    //           "name": "rx",
+    //           "is_verbose": false,
+    //           "is_long_running": false
+    //         },
+    //         "elapsed_ns": 603081749,
+    //         "children": []
+    //       }
+    //     ]
+    //   },
+    //   "detached": [
+    //     {
+    //       "id": 4,
+    //       "span": {
+    //         "name": "fut",
+    //         "is_verbose": false,
+    //         "is_long_running": false
+    //       },
+    //       "elapsed_ns": 1108412791,
+    //       "children": []
+    //     }
+    //   ]
+    // }
+    println!("{tree}");
+
+    tx.send(()).unwrap();
+    sleep(Duration::from_secs(1)).await;
+    let tree = serde_json::to_string_pretty(&registry.get(()).unwrap()).unwrap();
+
+    // {
+    //   "current": 1,
+    //   "tree": {
+    //     "id": 1,
+    //     "span": {
+    //       "name": "work",
+    //       "is_verbose": false,
+    //       "is_long_running": true
+    //     },
+    //     "elapsed_ns": 2114497458,
+    //     "children": [
+    //       {
+    //         "id": 4,
+    //         "span": {
+    //           "name": "fut",
+    //           "is_verbose": false,
+    //           "is_long_running": false
+    //         },
+    //         "elapsed_ns": 2114366458,
+    //         "children": []
+    //       }
+    //     ]
+    //   },
+    //   "detached": []
+    // }
+    println!("{tree}");
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,7 +67,8 @@ pub struct Tree {
 
 // TODO: make this optional with feature flag
 mod serde_impl {
-    use serde::{ser::SerializeStruct as _, Serialize};
+    use serde::ser::SerializeStruct as _;
+    use serde::Serialize;
 
     use super::*;
 
@@ -76,7 +77,7 @@ mod serde_impl {
         node: NodeId,
     }
 
-    impl<'a> Serialize for SpanNodeSer<'a> {
+    impl Serialize for SpanNodeSer<'_> {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: serde::Serializer,
@@ -220,7 +221,7 @@ impl Tree {
             .iter()
             .filter(|n| !n.is_removed()) // still valid
             .map(|node| self.arena.get_node_id(node).unwrap()) // get id
-            .filter(|&id| id != self.root && self.arena[id].parent().is_none()) // no parent but not root
+            .filter(|&id| id != self.root && self.arena[id].parent().is_none()) // no parent but non-root
     }
 
     /// Push a new span as a child of current span, used for future firstly polled.

--- a/src/span.rs
+++ b/src/span.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use serde::Serialize;
+
 type SpanName = flexstr::SharedStr;
 
 #[doc(hidden)]
@@ -42,7 +44,7 @@ macro_rules! span {
 }
 
 /// A cheaply cloneable span in the await-tree.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Span {
     pub(crate) name: SpanName,
     pub(crate) is_verbose: bool,

--- a/src/span.rs
+++ b/src/span.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use serde::Serialize;
-
 type SpanName = flexstr::SharedStr;
 
 #[doc(hidden)]
@@ -44,7 +42,7 @@ macro_rules! span {
 }
 
 /// A cheaply cloneable span in the await-tree.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
 pub struct Span {
     pub(crate) name: SpanName,
     pub(crate) is_verbose: bool,


### PR DESCRIPTION
Preview of the output:

```json
{
  "current": 1,
  "tree": {
    "id": 1,
    "span": {
      "name": "work",
      "is_verbose": false,
      "is_long_running": true
    },
    "elapsed_ns": 1108552791,
    "children": [
      {
        "id": 3,
        "span": {
          "name": "rx",
          "is_verbose": false,
          "is_long_running": false
        },
        "elapsed_ns": 603081749,
        "children": []
      }
    ]
  },
  "detached": [
    {
      "id": 4,
      "span": {
        "name": "fut",
        "is_verbose": false,
        "is_long_running": false
      },
      "elapsed_ns": 1108412791,
      "children": []
    }
  ]
}
```