### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2025-04-09
+
+### Added
+- Added `span!` macro as a replacement for `format!` with better performance ([#21](https://github.com/risingwavelabs/await-tree/pull/21))
+- Added support for global registry and updated its documentation ([#17](https://github.com/risingwavelabs/await-tree/pull/17), [#18](https://github.com/risingwavelabs/await-tree/pull/18))
+- Implemented `serde::Serialize` for tree to provide structured output and made it an optional feature ([#22](https://github.com/risingwavelabs/await-tree/pull/22), [#24](https://github.com/risingwavelabs/await-tree/pull/24))
+- Added attributes `long_running` and `verbose` on span, removed `verbose_instrument_await` ([#20](https://github.com/risingwavelabs/await-tree/pull/20))
+
+### Changed
+- Only depend on `tokio` if spawn capability is desired ([#25](https://github.com/risingwavelabs/await-tree/pull/25))
+- Added workflow for publishing crates ([#23](https://github.com/risingwavelabs/await-tree/pull/23))
+
+### Fixed
+- Fixed examples and added CI for running examples ([#19](https://github.com/risingwavelabs/await-tree/pull/19))
+
+[0.3.0]: https://github.com/risingwavelabs/await-tree/compare/v0.2.1...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "await-tree"
-version = "0.3.0-alpha.3"
+version = "0.3.0"
 edition = "2021"
 description = "Generate accurate and informative tree dumps of asynchronous tasks."
 repository = "https://github.com/risingwavelabs/await-tree"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ which is constantly transformed over the polling, completion, and cancellation o
 
 ```rust
 async fn bar(i: i32) {
-    // `&'static str` span
+    // static span
     baz(i).instrument_await("baz in bar").await
 }
 
@@ -24,8 +24,9 @@ async fn baz(i: i32) {
 async fn foo() {
     // spans of joined futures will be siblings in the tree
     join(
-        bar(3).instrument_await("bar"),
-        baz(2).instrument_await("baz"),
+        // attribute the span with `long_running` or `verbose`
+        bar(3).instrument_await("bar".long_running()),
+        baz(2).instrument_await("baz".verbose()),
     )
     .await;
 }


### PR DESCRIPTION
This PR bumps the version from 0.3.0-alpha.3 to 0.3.0 for the official release.