### PR TITLE
add support for `boxed` keyword in `instrument` attribute and bump versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "await-tree-attributes"]
 
 [package]
 name = "await-tree"
-version = "0.3.2-alpha.1"
+version = "0.3.2-alpha.2"
 edition = "2021"
 description = "Generate accurate and informative tree dumps of asynchronous tasks."
 repository = "https://github.com/risingwavelabs/await-tree"
@@ -18,7 +18,7 @@ tokio = ["dep:tokio"]
 attributes = ["dep:await-tree-attributes"]
 
 [dependencies]
-await-tree-attributes = { path = "await-tree-attributes", version = "0.1.0-alpha.1", optional = true }
+await-tree-attributes = { path = "await-tree-attributes", version = "0.1.0-alpha.2", optional = true }
 coarsetime = "0.1"
 derive_builder = "0.20"
 easy-ext = "1"

--- a/await-tree-attributes/Cargo.toml
+++ b/await-tree-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "await-tree-attributes"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 description = "Procedural attributes for await-tree instrumentation"
 repository = "https://github.com/risingwavelabs/await-tree"

--- a/await-tree-attributes/tests/expansion.rs
+++ b/await-tree-attributes/tests/expansion.rs
@@ -80,6 +80,36 @@ async fn test_keywords() {
     assert_eq!(result, 42);
 }
 
+// Test with boxed keyword
+#[instrument(boxed, "boxed_task({})", value)]
+async fn boxed_task(value: i32) -> i32 {
+    value * 3
+}
+
+// Test with boxed and other keywords
+#[instrument(boxed, long_running, "boxed_long_running_task")]
+async fn boxed_long_running_task() -> String {
+    "boxed and long running".to_owned()
+}
+
+// Test with boxed but no format args
+#[instrument(boxed)]
+async fn boxed_no_args_task() -> i32 {
+    100
+}
+
+#[tokio::test]
+async fn test_boxed_keyword() {
+    let result = boxed_task(7).await;
+    assert_eq!(result, 21);
+
+    let result = boxed_long_running_task().await;
+    assert_eq!(result, "boxed and long running");
+
+    let result = boxed_no_args_task().await;
+    assert_eq!(result, 100);
+}
+
 // Note: The attribute now accepts any identifiers as method names.
 // If the methods don't exist on Span, it will fail at compile time, which is the desired behavior.
 // For example, this would fail to compile:


### PR DESCRIPTION
Introduce the `boxed` keyword to the `instrument` attribute for improved stack management in async functions. Update package versions to reflect these changes.